### PR TITLE
Get sqltyped up to date with Scala 2.11

### DIFF
--- a/core/src/main/scala/jdbc.scala
+++ b/core/src/main/scala/jdbc.scala
@@ -26,8 +26,8 @@ private[sqltyped] object Jdbc {
 
   def inferOutput(meta: ResultSetMetaData) = 
     (1 to meta.getColumnCount).toList map { i => 
-      TypedValue(meta.getColumnName(i), (mkType(meta.getColumnClassName(i)), meta.getColumnType(i)), 
-                 meta.isNullable(i) == ResultSetMetaData.columnNullable, None, unknownTerm)
+      TypedValue(meta.getColumnLabel(i), (mkType(meta.getColumnClassName(i)), meta.getColumnType(i)), 
+                 meta.isNullable(i) != ResultSetMetaData.columnNoNulls, None, unknownTerm)
     }
 
   def unknownTerm = Ast.Column("unknown", Ast.Table("unknown", None))

--- a/core/src/main/scala/macro.scala
+++ b/core/src/main/scala/macro.scala
@@ -295,7 +295,7 @@ object SqlMacro {
     def returnTypeSigRecord = List(meta.output.foldRight(Ident(c.mirror.staticClass("shapeless.HNil")): Tree) { (x, sig) => 
       AppliedTypeTree(
         Ident(c.mirror.staticClass("shapeless.$colon$colon")), 
-        List(AppliedTypeTree(Select(Ident(c.mirror.staticModule("shapeless.record")), newTypeName("FieldType")), List(Select(Ident(newTermName(keyName(x))), newTypeName("T")), possiblyOptional(x, scalaType(x)))), sig)
+        List(AppliedTypeTree(Select(Ident(c.mirror.staticModule("shapeless.labelled")), newTypeName("FieldType")), List(Select(Ident(newTermName(keyName(x))), newTypeName("T")), possiblyOptional(x, scalaType(x)))), sig)
       )
     })
 

--- a/core/src/main/scala/macro.scala
+++ b/core/src/main/scala/macro.scala
@@ -204,13 +204,15 @@ object SqlMacro {
           List(ValDef(Modifiers(), newTermName("x"), TypeTree(), getValue(x, pos))), 
           If(Apply(Select(Ident(newTermName("rs")), newTermName("wasNull")), List()), 
              Select(Ident(newTermName("scala")), newTermName("None")), 
-             Apply(Select(Select(Ident(newTermName("scala")), newTermName("Some")), newTermName("apply")), List(Ident(newTermName("x"))))))
-      } else getValue(x, pos)
+             Apply(Select(Select(Ident(newTermName("scala")), newTermName("Some")), newTermName("apply")), List(getTyped(x, Ident(newTermName("x")))))))
+      } else getTyped(x, getValue(x, pos))
 
-    def getValue(x: TypedValue, pos: Int) = {
-      def baseValue = Typed(Apply(Select(Ident(newTermName("rs")), newTermName(rsGetterName(x))), 
-                                  List(Literal(Constant(pos)))), scalaBaseType(x))
-      
+    def getValue(x: TypedValue, pos: Int) =
+      Apply(Select(Ident(newTermName("rs")), newTermName(rsGetterName(x))), List(Literal(Constant(pos))))
+
+    def getTyped(x: TypedValue, r: Tree) = {
+      def baseValue = Typed(r, scalaBaseType(x))
+
       (if (enableTagging) x.tag else None) map(t => tagType(t)) map (tagged =>
         Apply(
           Select(
@@ -381,7 +383,7 @@ object SqlMacro {
                        If(Apply(Select(Ident(newTermName("rs")), newTermName("next")), List()), 
                           Block(
                             List(
-                              Apply(Select(Ident(newTermName("keys")), newTermName("append")), List(getValue(keyType, 1)))), 
+                              Apply(Select(Ident(newTermName("keys")), newTermName("append")), List(getTyped(keyType, getValue(keyType, 1))))), 
                             Apply(Ident(newTermName("while$1")), List())), Literal(Constant(())))), 
               Apply(Select(Ident(newTermName("rs")), newTermName("close")), List())), 
             Select(Ident(newTermName("keys")), newTermName("toList")))))

--- a/core/src/main/scala/macro.scala
+++ b/core/src/main/scala/macro.scala
@@ -147,6 +147,7 @@ object SqlMacro {
 
     def fallback = for {
       db   <- dbConfig
+      _ = Class.forName(db.driver)
       meta <- Jdbc.infer(db, sql)
     } yield meta
 
@@ -168,7 +169,7 @@ object SqlMacro {
       meta      <- timer("analyzing", 2, if (analyze) new Analyzer(typer).refine(resolved, typed) else typed.ok)
     } yield meta }) fold (
       fail => fallback fold ( 
-        _ => c.abort(toPosition(fail), fail.message), 
+        fail2 => c.abort(toPosition(fail2), fail2.message), 
         meta => { 
           c.warning(toPosition(fail), fail.message + "\nFallback to JDBC metadata. Please file a bug at https://github.com/jonifreeman/sqltyped/issues")
           timer("codegen", 2, generateCode(meta))

--- a/core/src/main/scala/package.scala
+++ b/core/src/main/scala/package.scala
@@ -25,7 +25,7 @@ package object sqltyped {
   implicit def optionOps[L <: HList](l: Option[L]): OptionOps[L] = new OptionOps(l)  
 
   // To reduce importing when using records...
-  implicit def mkSingletonOps(t: Any) = macro SingletonTypeMacros.mkSingletonOps
+  implicit def mkSingletonOps(t: Any): syntax.SingletonOps = macro SingletonTypeMacros.mkSingletonOps
 
   // Internally ? is used to denote computations that may fail.
   private[sqltyped] def fail[A](s: String, column: Int = 0, line: Int = 0): ?[A] = 

--- a/core/src/main/scala/record.scala
+++ b/core/src/main/scala/record.scala
@@ -1,6 +1,6 @@
 package sqltyped
 
-import shapeless._, ops.hlist._, ops.record._, record.FieldType
+import shapeless._, ops.hlist._, ops.record._, labelled.FieldType
 
 object Record {
   private object fieldToUntyped extends Poly1 {

--- a/demo/project/build.scala
+++ b/demo/project/build.scala
@@ -4,13 +4,13 @@ import Keys._
 object DemoBuild extends Build {
   lazy val demoSettings = Defaults.defaultSettings ++ Seq(
     organization := "com.example",
-    version := "0.4",
-    scalaVersion := "2.10.4",
+    version := "0.4.1",
+    scalaVersion := "2.11.7",
     scalacOptions ++= Seq("-unchecked", "-deprecation"),
     javacOptions ++= Seq("-target", "1.6", "-source", "1.6"),
     crossPaths := false,
     libraryDependencies ++= Seq(
-      "fi.reaktor" %% "sqltyped" % "0.4.0",
+      "fi.reaktor" %% "sqltyped" % "0.4.1",
       "fi.reaktor" %% "sqltyped-json4s" % "0.4.0",
       "com.typesafe" %% "slick" % "1.0.0-RC1",
       "net.databinder" %% "unfiltered" % "0.6.5",

--- a/json4s/src/main/scala/json.scala
+++ b/json4s/src/main/scala/json.scala
@@ -5,6 +5,7 @@ import native.JsonMethods
 import JsonMethods._
 
 import shapeless._
+import labelled._
 import poly._
 import ops.hlist._
 import syntax.singleton._

--- a/project/build.scala
+++ b/project/build.scala
@@ -5,16 +5,16 @@ object SqltypedBuild extends Build with Publish {
   import Resolvers._
 
   lazy val versionFormat = "%s"
-  lazy val majorVersion = "0.4.0"
+  lazy val majorVersion = "0.4.1"
 //  lazy val versionFormat = "%s-SNAPSHOT"
 
   lazy val sqltypedSettings = Defaults.defaultSettings ++ publishSettings ++ Seq(
     organization := "fi.reaktor",
     version := versionFormat format majorVersion,
-    scalaVersion := "2.10.4",
+    scalaVersion := "2.11.7",
     scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature"),
     javacOptions ++= Seq("-target", "1.6", "-source", "1.6"),
-    crossScalaVersions := Seq("2.10"),
+    crossScalaVersions := Seq("2.11"),
     parallelExecution in Test := false,
     resolvers ++= Seq(sonatypeNexusSnapshots, sonatypeNexusReleases)
   )
@@ -26,11 +26,12 @@ object SqltypedBuild extends Build with Publish {
     base = file("core"),
     settings = sqltypedSettings ++ Seq(
       libraryDependencies ++= Seq(
-        "com.chuusai" % "shapeless_2.10.4" % "2.0.0",
+        "com.chuusai" %% "shapeless" % "2.3.0",
         "net.sourceforge.schemacrawler" % "schemacrawler" % "8.17",
-        "org.scala-lang" % "scala-reflect" % "2.10.2",
-        "org.scalatest" %% "scalatest" % "2.0.M5b" % "test",
-        "org.scala-lang" % "scala-actors" % "2.10.2" % "test",
+        "org.scala-lang" % "scala-reflect" % "2.11.7",
+        "org.scalatest" %% "scalatest" % "2.2.6" % "test",
+        "org.scala-lang" % "scala-actors" % "2.11.7" % "test",
+        "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4",
         "mysql" % "mysql-connector-java" % "5.1.21" % "test",
         "postgresql" % "postgresql" % "9.1-901.jdbc4" % "test"
       ),
@@ -43,7 +44,7 @@ object SqltypedBuild extends Build with Publish {
     base = file("json4s"),
     settings = sqltypedSettings ++ Seq(
       libraryDependencies ++= Seq(
-        "org.json4s" %% "json4s-native" % "3.2.4"
+        "org.json4s" %% "json4s-native" % "3.3.0"
       )
     )
   ) dependsOn(core % "compile;test->test;provided->provided")


### PR DESCRIPTION
I know you've [mentioned](https://github.com/jonifreeman/sqltyped/issues/11) that you're not maintaining sqltyped right now, but I'd like to see it live on, as it has some features that I don't see with the alternatives:
- like you said, Slick has a typed sql feature, but I do not like the fact that it infers the types only and doesn't take column names into account. With many columns with the same type and with typos in long column names this doesn't help too much.
- doobie has an interesting approach (https://tpolecat.github.io/doobie-0.2.3/06-Checking.html) where one can check the query at runtime but without the need to actually run it. This makes it an acceptable alternative to typed queries. However, even though doobie works with records, it discards the column names (https://github.com/tpolecat/doobie/issues/277) and uses positions only, which is counterintuitive after having seen sqltyped. This also makes using records seem unnecessarily difficult since unlike sqltyped they are constructed manually.

Regarding compilation speed, it's true that shapeless does impose a tax on compile times, but things seem to have improved in recent editions. I haven't actually checked to compare with older versions, but it seems the complexity of some operations has been optimized: https://github.com/milessabin/shapeless/issues/50

I'd like to hear your thoughts on future development of sqltyped and whether you'd want or have the time to provide some a small piece of help once in a while:
- updating the public maven repo is still maintained by you- are you willing to publish stuff from new pull requests?
- providing some advice on some future features which are tied to some knowledge that you already have, like why sqltyped has chosen to choose a certain design and not another

Thanks in advance for any help you can offer!
